### PR TITLE
Use a borrow when creating a new_stream using a Subreddit

### DIFF
--- a/src/structures/subreddit.rs
+++ b/src/structures/subreddit.rs
@@ -67,9 +67,9 @@ impl<'a> Subreddit<'a> {
     ///
     /// }
     /// ```
-    pub fn new_stream(self) -> PostStream<'a> {
+    pub fn new_stream(&self) -> PostStream<'a> {
         let url = format!("/r/{}/new?limit=5", self.name);
-        PostStream::new(&self.client, url)
+        PostStream::new(self.client, url)
     }
 
     /// Gets a listing of the new feed for this subreddit.


### PR DESCRIPTION
Currently, calling `Subreddit::new_stream` consumes the `Subreddit`, which is unlike the other methods provided by `Subreddit`, and seems to be unnecessary.  This pull request uses an immutable borrow of `self` in the `new_stream` method, instead of moving the subreddit into the method.

**Edit:** Also, if you don't want me making PR's to this repo, I can redirect to the parent, but that repo looks kinda dead atm, and I doubt that any PRs to there are going to be considered, so I went with this one, which seems to be the most usable fork atm.