### PR TITLE
VecDeque.contains has been stabilized

### DIFF
--- a/src/structures/comment_list.rs
+++ b/src/structures/comment_list.rs
@@ -233,14 +233,8 @@ impl<'a> Iterator for CommentStream<'a> {
             if next_iter.is_some() {
                 let res = next_iter.unwrap();
                 let name = res.name().to_owned();
-                // VecDeque.contains is not stable yet!
-                let mut contains = false;
-                for item in &self.set {
-                    if item == &name {
-                        contains = true;
-                    }
-                }
-                if contains {
+
+                if self.set.contains(name) {
                     self.current_iter = Some(iter);
                     self.next()
                 } else {

--- a/src/structures/comment_list.rs
+++ b/src/structures/comment_list.rs
@@ -234,7 +234,7 @@ impl<'a> Iterator for CommentStream<'a> {
                 let res = next_iter.unwrap();
                 let name = res.name().to_owned();
 
-                if self.set.contains(name) {
+                if self.set.contains(&name) {
                     self.current_iter = Some(iter);
                     self.next()
                 } else {

--- a/src/structures/listing.rs
+++ b/src/structures/listing.rs
@@ -153,14 +153,8 @@ impl<'a> Iterator for PostStream<'a> {
             if next_iter.is_some() {
                 let res = next_iter.unwrap();
                 let name = res.name().to_owned();
-                // VecDeque.contains is not stable yet!
-                let mut contains = false;
-                for item in &self.set {
-                    if item == &name {
-                        contains = true;
-                    }
-                }
-                if contains {
+
+                if self.set.contains(&name) {
                     self.current_iter = Some(iter);
                     self.next()
                 } else {


### PR DESCRIPTION
A couple of areas in the code reference VecDeque not being stabilized, but it has since been stabilized [\[see rust docs\]](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.contains).  Switching out existing code for this method will likely improve performance,  readability, and stability.